### PR TITLE
enable using different regions for LLM and Data Storage

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -21,6 +21,7 @@ export TABLE_NAME=BedrockChatStack-DatabaseConversationTablexxxx
 export ACCOUNT=yyyy
 export REGION=ap-northeast-1
 export BEDROCK_REGION=us-east-1
+export MODEL_REGION=us-east-1
 export DOCUMENT_BUCKET=bedrockchatstack-documentbucketxxxxxxx
 ```
 

--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -7,7 +7,7 @@ from app.repositories.model import MessageModel
 from botocore.client import Config
 from botocore.exceptions import ClientError
 
-BEDROCK_REGION = os.environ.get("BEDROCK_REGION", "us-east-1")
+MODEL_REGION = os.environ.get("MODEL_REGION", "us-east-1")
 
 
 def is_running_on_lambda():

--- a/frontend/src/i18n/en/index.ts
+++ b/frontend/src/i18n/en/index.ts
@@ -24,7 +24,7 @@ const translation = {
         notAvailable: 'This bot is NOT available.',
         noBots: 'No Bots.',
         noBotsRecentlyUsed: 'No Recently Used Shared Bots.',
-        retrivingKnowledge: '[Retriving Knowledge...]',
+        retrivingKnowledge: '[Retrieving Knowledge...]',
         dndFileUpload:
           'You can upload files by drag and drop.\nSupported files: {{fileExtensions}}',
         uploadError: 'Error Message',


### PR DESCRIPTION
We, an EU company, want to keep our data in the EU, however we have to use the LLM in the US as the LLM in EU is limited. This small add of a DATA_REGION var enables you to keep the regions seperated